### PR TITLE
feat(users/nick): consume fish from dotfiles HM module

### DIFF
--- a/compute/flake.lock
+++ b/compute/flake.lock
@@ -49,11 +49,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774767241,
-        "narHash": "sha256-HDumwvBOTZ1/MejUvxYNH1ttPcAxSed+tk07NzXI0VE=",
+        "lastModified": 1774804078,
+        "narHash": "sha256-L+QfkrKWdfy0NxEBPgFY1xLBXAoCIzFo673n+1p1Iq0=",
         "owner": "iamnande",
         "repo": "dotfiles",
-        "rev": "a07bca5b899a60bcb3753488c119498280324557",
+        "rev": "5ce40dab485250897558d432daa91b105e7f8d72",
         "type": "github"
       },
       "original": {

--- a/compute/modules/users/nick.nix
+++ b/compute/modules/users/nick.nix
@@ -12,7 +12,6 @@
   };
 
   environment.systemPackages = with pkgs; [
-    fishPlugins.tide
     stow
     zellij
   ];
@@ -53,7 +52,7 @@
           if [ ! -d "$HOME/dotfiles" ]; then
             git clone https://github.com/iamnande/dotfiles.git "$HOME/dotfiles"
             cd "$HOME/dotfiles"
-            make fish && make helix && make zellij && make claude
+            make helix && make zellij && make claude
           fi
         ''}";
       };


### PR DESCRIPTION
## why

fish config is now fully managed by the dotfiles HM module. homelab wires in the updated module and drops the redundant system-level pieces. tracked in homelab#15.

## how

- removes `fishPlugins.tide` from `environment.systemPackages` — tide now in `home.packages` via the dotfiles module
- drops `make fish` from `dotfiles-setup` ExecStart — fish config is covered by HM on rebuild
- updates dotfiles flake input to `feat/4_fish-hm-migration` for validation (will point to main post-merge)

## validation

```fish
nh os switch .                 # devbox-nick
# open new shell: tide prompt, no greeting
echo $SSH_AUTH_SOCK            # expect: /home/nick/.ssh/agent.sock
fish -c 'functions k'          # expect: kubectl $argv
```