### PR TITLE
feat(users/nick): consume helix from dotfiles HM module

### DIFF
--- a/compute/flake.lock
+++ b/compute/flake.lock
@@ -49,15 +49,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1774804078,
-        "narHash": "sha256-L+QfkrKWdfy0NxEBPgFY1xLBXAoCIzFo673n+1p1Iq0=",
+        "lastModified": 1774804758,
+        "narHash": "sha256-Ii8a8zYG2xdCsPFLswVgougK2x63TPyH3Qg2rTy6rGU=",
         "owner": "iamnande",
         "repo": "dotfiles",
-        "rev": "5ce40dab485250897558d432daa91b105e7f8d72",
+        "rev": "de1901444879b03939841eeac3839185c92989e0",
         "type": "github"
       },
       "original": {
         "owner": "iamnande",
+        "ref": "feat/4_helix-hm-migration",
         "repo": "dotfiles",
         "type": "github"
       }

--- a/compute/flake.nix
+++ b/compute/flake.nix
@@ -20,7 +20,7 @@
     };
 
     dotfiles = {
-      url = "github:iamnande/dotfiles";
+      url = "github:iamnande/dotfiles/feat/4_helix-hm-migration";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };

--- a/compute/modules/users/nick.nix
+++ b/compute/modules/users/nick.nix
@@ -52,7 +52,7 @@
           if [ ! -d "$HOME/dotfiles" ]; then
             git clone https://github.com/iamnande/dotfiles.git "$HOME/dotfiles"
             cd "$HOME/dotfiles"
-            make helix && make zellij && make claude
+            make zellij && make claude
           fi
         ''}";
       };


### PR DESCRIPTION
## why

helix config now managed by the dotfiles HM module. homelab#15.

## how

- drops `make helix` from dotfiles-setup ExecStart
- updates dotfiles flake input

## validation

```fish
nh os switch ~/homelab/compute
hx --version
```