### PR TITLE
chore(users/nick): drop make zellij from dotfiles-setup

### DIFF
--- a/compute/modules/users/nick.nix
+++ b/compute/modules/users/nick.nix
@@ -52,7 +52,7 @@
           if [ ! -d "$HOME/dotfiles" ]; then
             git clone https://github.com/iamnande/dotfiles.git "$HOME/dotfiles"
             cd "$HOME/dotfiles"
-            make zellij && make claude
+            make claude
           fi
         ''}";
       };


### PR DESCRIPTION
## why

zellij stow component removed — nothing to install. homelab#15.

## how

- drops `make zellij` from dotfiles-setup ExecStart

## validation

no rebuild needed — existing live config unaffected.