### PR TITLE
feat(users/nick): migrate claude to home-manager, retire stow

### DIFF
--- a/compute/flake.lock
+++ b/compute/flake.lock
@@ -49,16 +49,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1774805699,
+        "lastModified": 1774806012,
         "narHash": "sha256-BAsbTUYgBqKClfDiFHeCMLgxNfhAmGMMorhht3E+UoE=",
         "owner": "iamnande",
         "repo": "dotfiles",
-        "rev": "94488e0ae1976f377440df1edc053876c018166b",
+        "rev": "0a9e2895421033f7a36fe19891d9671399f30e6f",
         "type": "github"
       },
       "original": {
         "owner": "iamnande",
-        "ref": "feat/4_claude-hm-migration",
         "repo": "dotfiles",
         "type": "github"
       }

--- a/compute/flake.nix
+++ b/compute/flake.nix
@@ -20,7 +20,7 @@
     };
 
     dotfiles = {
-      url = "github:iamnande/dotfiles/feat/4_claude-hm-migration";
+      url = "github:iamnande/dotfiles";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };


### PR DESCRIPTION
## why

claude config is now managed by the dotfiles HM module. this is the final stow component — stow is fully retired. homelab#15.

## how

- drops `make claude` and the entire `dotfiles-setup` systemd service — nothing left to stow
- removes `stow` from `environment.systemPackages`
- updates dotfiles flake input to main

## validation

```fish
nh os switch ~/homelab/compute
# open new shell — claude skills still available
systemctl --user status dotfiles-setup  # unit should no longer exist
```