### PR TITLE
chore(users/nick): drop zellij system package, managed by home-manager

### DIFF
--- a/compute/flake.lock
+++ b/compute/flake.lock
@@ -44,11 +44,11 @@
     },
     "dotfiles": {
       "locked": {
-        "lastModified": 1774837891,
-        "narHash": "sha256-LNbL8v/RQ8WAlqsgQPpTwjq3/GUiC+RoVdUM8zlBo0s=",
+        "lastModified": 1774838813,
+        "narHash": "sha256-WvioXZlxThNI+U4M1iRTRg+Xa92ywDsP4P7QJQbkfoI=",
         "owner": "iamnande",
         "repo": "dotfiles",
-        "rev": "1ac8d8349ca860d9d5f4e52cfb569486a30426ae",
+        "rev": "ceebb59212837222d60fe9a946b61fa19e7d8dd7",
         "type": "github"
       },
       "original": {

--- a/compute/flake.lock
+++ b/compute/flake.lock
@@ -44,11 +44,11 @@
     },
     "dotfiles": {
       "locked": {
-        "lastModified": 1774834337,
-        "narHash": "sha256-JSC8s38qFCXgPGAbT8mVpv9bGfOOjNt8jcJ2DQ+DO1g=",
+        "lastModified": 1774837891,
+        "narHash": "sha256-LNbL8v/RQ8WAlqsgQPpTwjq3/GUiC+RoVdUM8zlBo0s=",
         "owner": "iamnande",
         "repo": "dotfiles",
-        "rev": "294e53f09c72abb6a71c16d53ed7609a49196c0f",
+        "rev": "1ac8d8349ca860d9d5f4e52cfb569486a30426ae",
         "type": "github"
       },
       "original": {

--- a/compute/modules/users/nick.nix
+++ b/compute/modules/users/nick.nix
@@ -11,10 +11,6 @@
     ];
   };
 
-  environment.systemPackages = with pkgs; [
-    zellij
-  ];
-
   home-manager.useGlobalPkgs = true;
   home-manager.useUserPackages = true;
   home-manager.sharedModules = [ inputs.dotfiles.homeManagerModules.nick ];


### PR DESCRIPTION
## why

Zellij is now managed by home-manager via the dotfiles flake (`homeManagerModules.nick`). Having it in `environment.systemPackages` is redundant and should be dropped to avoid the duplicate.

## how

- Remove `environment.systemPackages` block with zellij from `compute/modules/users/nick.nix`
- Update dotfiles flake input to current main (`ceebb59`)

## validation

```
nh os switch ~/homelab/compute
zellij --version  # should still work via home-manager
```